### PR TITLE
Update requests requirement in the pip group across 1 directory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ prometheus-api-client==0.5.*
 pylint==3.3.*
 pytest-subtests==0.12.*
 pytest-testinfra==10.1.*
-requests==2.31.*
+requests==2.32.*


### PR DESCRIPTION
This PR was originally created by dependabot, and manually re-created to allow CI to run 

Updates the requirements on [requests](https://github.com/psf/requests) to permit the latest version.

Updates `requests` to 2.32.3
- [Release notes](https://github.com/psf/requests/releases)
- [Changelog](https://github.com/psf/requests/blob/main/HISTORY.md)
- [Commits](https://github.com/psf/requests/compare/v2.31.0...v2.32.3)

---
updated-dependencies:
- dependency-name: requests dependency-type: direct:production dependency-group: pip ...